### PR TITLE
First pass at variable expiry, set in the config file per-client

### DIFF
--- a/cmd/dex/serve.go
+++ b/cmd/dex/serve.go
@@ -209,14 +209,10 @@ func runServe(options serveOptions) error {
 				}
 				c.StaticClients[i].Secret = os.Getenv(client.SecretEnv)
 			}
-
 			if client.IDTokenExpiry != "" {
-				d, err := time.ParseDuration(client.ID)
-				if err != nil {
-					return fmt.Errorf("invalid config: IDTokenExpiry failed to parse for client %q", client.ID)
+				if _, err := time.ParseDuration(client.IDTokenExpiry); err != nil {
+					return fmt.Errorf("invalid config: IDTokenExpiry field must be a valid duration for client %q", client.ID)
 				}
-				// It's awkward to check here that this is less than the global Expiry.IDToken, so we just won't do it.
-				client.IDTokenExpiryDur = d
 			}
 			logger.Infof("config static client: %s", client.Name)
 		}

--- a/cmd/dex/serve.go
+++ b/cmd/dex/serve.go
@@ -209,6 +209,15 @@ func runServe(options serveOptions) error {
 				}
 				c.StaticClients[i].Secret = os.Getenv(client.SecretEnv)
 			}
+
+			if client.IDTokenExpiry != "" {
+				d, err := time.ParseDuration(client.ID)
+				if err != nil {
+					return fmt.Errorf("invalid config: IDTokenExpiry failed to parse for client %q", client.ID)
+				}
+				// It's awkward to check here that this is less than the global Expiry.IDToken, so we just won't do it.
+				client.IDTokenExpiryDur = d
+			}
 			logger.Infof("config static client: %s", client.Name)
 		}
 		s = storage.WithStaticClients(s, c.StaticClients)

--- a/examples/config-dev.yaml
+++ b/examples/config-dev.yaml
@@ -75,14 +75,14 @@ telemetry:
 
 # Uncomment this block to enable configuration for the expiration time durations.
 # Is possible to specify units using only s, m and h suffixes.
-# expiry:
-#   deviceRequests: "5m"
-#   signingKeys: "6h"
-#   idTokens: "24h"
-#   refreshTokens:
-#     reuseInterval: "3s"
-#     validIfNotUsedFor: "2160h" # 90 days
-#     absoluteLifetime: "3960h" # 165 days
+expiry:
+  deviceRequests: "5m"
+  signingKeys: "6h"
+  idTokens: "48h"
+  refreshTokens:
+    reuseInterval: "3s"
+    validIfNotUsedFor: "2160h" # 90 days
+    absoluteLifetime: "3960h" # 165 days
 
 # Options for controlling the logger.
 # logger:
@@ -112,10 +112,11 @@ staticClients:
   - 'http://127.0.0.1:5555/callback'
   name: 'Example App'
   secret: ZXhhbXBsZS1hcHAtc2VjcmV0
+  idTokenExpiry: "12h"
 - id: IrbblpeZJRMewq8suTx0PcmHlporj6yZ
   redirectURIs:
   - 'http://localhost:3000'
-  name: 'Example App'
+  name: 'Example App 2'
   public: true
 #  - id: example-device-client
 #    redirectURIs:

--- a/server/oauth2.go
+++ b/server/oauth2.go
@@ -318,11 +318,12 @@ func (s *Server) newIDToken(clientID string, claims storage.Claims, scopes []str
 	validFor := s.idTokensValidFor
 
 	if client.IDTokenExpiry != "" {
-		if clientValidFor, err := time.ParseDuration(client.IDTokenExpiry); err != nil {
+		switch clientValidFor, err := time.ParseDuration(client.IDTokenExpiry); {
+		case err != nil:
 			s.logger.Errorf("Client %q custom ID token expiry %q not a valid duration, this should never happen; using global setting of %q", clientID, client.IDTokenExpiry, s.idTokensValidFor)
-		} else if clientValidFor > s.idTokensValidFor {
+		case clientValidFor > s.idTokensValidFor:
 			s.logger.Errorf("Client %q custom ID token expiry %q longer than the global setting of %s; using the latter", clientID, client.IDTokenExpiry, s.idTokensValidFor)
-		} else {
+		default:
 			validFor = clientValidFor
 		}
 	}

--- a/storage/static.go
+++ b/storage/static.go
@@ -2,7 +2,6 @@ package storage
 
 import (
 	"errors"
-	"fmt"
 	"strings"
 
 	"github.com/dexidp/dex/pkg/log"
@@ -26,7 +25,6 @@ type staticClientsStorage struct {
 func WithStaticClients(s Storage, staticClients []Client) Storage {
 	clientsByID := make(map[string]Client, len(staticClients))
 	for _, client := range staticClients {
-		fmt.Printf("%+v\n", client)
 		clientsByID[client.ID] = client
 	}
 
@@ -34,9 +32,7 @@ func WithStaticClients(s Storage, staticClients []Client) Storage {
 }
 
 func (s staticClientsStorage) GetClient(id string) (Client, error) {
-	fmt.Printf("They're trying to get %s\n", id)
 	if client, ok := s.clientsByID[id]; ok {
-		fmt.Printf("Found me in the map, %+v", client)
 		return client, nil
 	}
 	return s.Storage.GetClient(id)

--- a/storage/static.go
+++ b/storage/static.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 
 	"github.com/dexidp/dex/pkg/log"
@@ -25,6 +26,7 @@ type staticClientsStorage struct {
 func WithStaticClients(s Storage, staticClients []Client) Storage {
 	clientsByID := make(map[string]Client, len(staticClients))
 	for _, client := range staticClients {
+		fmt.Printf("%+v\n", client)
 		clientsByID[client.ID] = client
 	}
 
@@ -32,7 +34,9 @@ func WithStaticClients(s Storage, staticClients []Client) Storage {
 }
 
 func (s staticClientsStorage) GetClient(id string) (Client, error) {
+	fmt.Printf("They're trying to get %s\n", id)
 	if client, ok := s.clientsByID[id]; ok {
+		fmt.Printf("Found me in the map, %+v", client)
 		return client, nil
 	}
 	return s.Storage.GetClient(id)

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -151,6 +151,15 @@ type Client struct {
 	// requested to redirect to MUST match one of these values, unless the client is "public".
 	RedirectURIs []string `json:"redirectURIs" yaml:"redirectURIs"`
 
+	// IDTokenExpiry overrides the global expiration length for id tokens. Note that this can only
+	// be less than the global setting. This lets us keep the public key rotation up-to-date for
+	// free.
+	//
+	// We do not store this in the database, it only works for static clients.
+	IDTokenExpiry string `json:"idTokenExpiry" yaml:"idTokenExpiry"`
+
+	IDTokenExpiryDur time.Duration `json:"-" yaml:"-"`
+
 	// TrustedPeers are a list of peers which can issue tokens on this client's behalf using
 	// the dynamic "oauth2:server:client_id:(client_id)" scope. If a peer makes such a request,
 	// this client's ID will appear as the ID Token's audience.

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -158,8 +158,6 @@ type Client struct {
 	// We do not store this in the database, it only works for static clients.
 	IDTokenExpiry string `json:"idTokenExpiry" yaml:"idTokenExpiry"`
 
-	IDTokenExpiryDur time.Duration `json:"-" yaml:"-"`
-
 	// TrustedPeers are a list of peers which can issue tokens on this client's behalf using
 	// the dynamic "oauth2:server:client_id:(client_id)" scope. If a peer makes such a request,
 	// this client's ID will appear as the ID Token's audience.


### PR DESCRIPTION
We don't want browser tokens to last very long, but we want mobile app tokens to last for a very long time. In order to accommodate this we introduce a new, optional configuration field `idTokenExpiry` for static clients:

```yaml
expiry:
  idToken: 12h
staticClients:
- id: example
  idTokenExpiry: 6h
```

It is important here that the client-specific expiry be less than the global value, because [the global value is used](https://github.com/dexidp/dex/blob/fd545e0493814db3392f5b021ad6b48e8def88b4/server/rotation.go#L163) to make sure we keep public keys around for sufficiently long. This is not elegant but it was quick to implement.

#### Caveats

* If the value for `idTokenExpiry` doesn't parse, we crash on startup.
* If the value for `idTokenExpiry` turns out to be greater than the global setting `expiry.idToken`, we'll just ignore it.
* If the client has a custom duration then we end up parsing this string every time we hand out an identity token. I could not get a `time.Duration` to persist on the `storage.Client` object and I don't have time to figure out why.
* This will not work for "dynamic" clients that are stored in the database, but we never use those anyway.